### PR TITLE
Add travis and revert to Juice 3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 before_script:
+  - npm install -g grunt-cli@latest
 
 script:
   - npm run travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+before_script:
+
+script:
+  - npm run travis
+
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "6"
+  - "7"
+  - "node"
+
+sudo: false

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,6 +47,12 @@ module.exports = function(grunt) {
           'tmp/out_with_important.html': 'test/fixtures/in.html'
         },
       },
+      does_not_exist: {
+        options: {},
+        files: {
+          'tmp/out_does_not_exist.html': 'test/fixtures/in_does_not_exist.html'
+        },
+      }
     },
 
     // Unit tests.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,10 +32,19 @@ module.exports = function(grunt) {
     inlinecss: {
       basic: {
         options: {
-          extraCss: 'body { background: green; }'
+          extraCss: 'body { background: green; }',
         },
         files: {
           'tmp/out.html': 'test/fixtures/in.html'
+        },
+      },
+      with_important: {
+        options: {
+          extraCss: 'body { background: green; }',
+          preserveImportant: true
+        },
+        files: {
+          'tmp/out_with_important.html': 'test/fixtures/in.html'
         },
       },
     },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "author": {
     "name": "Greg Allen"
   },
+  "contributors": [
+    {
+      "name": "Simon Bruce"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/jgallen23/grunt-inline-css.git"
@@ -24,7 +29,8 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "travis": "grunt test"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~1.1.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "juice": "~4.0.2"
+    "juice": "~3.0.1"
   }
 }

--- a/tasks/inline_css.js
+++ b/tasks/inline_css.js
@@ -22,17 +22,26 @@ module.exports = function(grunt) {
     var index = 0;
     var count = this.files.length;
 
+    var increaseCount = function () {
+      index++;
+      if (index === count) {
+        done();
+      }
+    };
+
     // Iterate over all specified file groups.
     this.files.forEach(function(f) {
 
       var filepath = f.src.toString();
       if (typeof filepath !== 'string' || filepath === '') {
         grunt.log.error('src must be a single string');
+        increaseCount();
         return false;
       }
 
       if (!grunt.file.exists(filepath)) {
         grunt.log.error('Source file "' + filepath + '" not found.');
+        increaseCount();
         return false;
       }
 
@@ -41,18 +50,16 @@ module.exports = function(grunt) {
       juice.juiceFile(filepath, options, function(err, html) {
 
         if (err) {
-          return grunt.log.error(err);
+          grunt.log.error(err);
+          increaseCount();
+
+          return;
         }
 
         grunt.file.write(f.dest, html);
         grunt.log.writeln('File "' + f.dest + '" created.');
 
-
-        index++;
-        if (index === count) {
-          done();
-        }
-
+        increaseCount();
       });
 
     });

--- a/tasks/inline_css.js
+++ b/tasks/inline_css.js
@@ -36,6 +36,8 @@ module.exports = function(grunt) {
         return false;
       }
 
+      grunt.log.writeln("filepath:", filepath);
+
       juice.juiceFile(filepath, options, function(err, html) {
 
         if (err) {

--- a/test/expected/out_with_important.html
+++ b/test/expected/out_with_important.html
@@ -5,7 +5,7 @@
     
   </head>
   <body style="font-family: Test, 'Segoe UI', Arial; background: green;">
-    <h1 style="border: 1px solid #ccc; color: blue; font-family: Arial;">Hi</h1>
+    <h1 style="border: 1px solid #ccc; color: blue; font-family: Arial !important;">Hi</h1>
     <table>
       <tr>
         <td class="headline" style="padding: 5px; font-size: 24px;">Some Headline</td>

--- a/test/fixtures/file.css
+++ b/test/fixtures/file.css
@@ -3,6 +3,7 @@ body {
 }
 h1 {
   color: blue;
+  font-family: Arial !important;
 }
 .headline {
   font-size: 24px;

--- a/test/inline_css_test.js
+++ b/test/inline_css_test.js
@@ -36,5 +36,15 @@ exports.inline_css = {
     test.equal(actual, expected, 'should inline css');
 
     test.done();
+  },
+
+  with_important: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/out_with_important.html');
+    var expected = grunt.file.read('test/expected/out_with_important.html');
+    test.equal(actual, expected, 'should inline css');
+
+    test.done();
   }
 };

--- a/test/inline_css_test.js
+++ b/test/inline_css_test.js
@@ -46,5 +46,22 @@ exports.inline_css = {
     test.equal(actual, expected, 'should inline css');
 
     test.done();
+  },
+
+  does_not_exist: function(test) {
+    test.expect(0);
+
+    try {
+      var actual = grunt.file.read('tmp/out_does_not_exist.html');
+    } catch(err) {
+
+      if (err.origError.code === 'ENOENT') {
+        return test.done();
+      }
+
+      return test.done(new Error('Should have errored with a file not found: ' + err.code));
+    }
+
+    test.done(new Error('Should have errored'));
   }
 };


### PR DESCRIPTION
This upgrades Juice to 3.0.1 to which fix's known issues but still allows support for Node 0.10 and 0.12. Travis CI support added. Extra tests added.