### PR TITLE
Allow to configure juice.codeBlocks to support general exclusion of fenced code, like EJS, HBS, etc. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ In your project's Gruntfile, add a section named `inlinecss` to the data object 
 grunt.initConfig({
 	inlinecss: {
 		main: {
+			codeBlocks: {
+			},
 			options: {
 			},
 			files: {

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ grunt.initConfig({
 })
 ```
 
-You can see available options [here](https://github.com/Automattic/juice/tree/v3.0.1#options)
+You can see available options [here](https://github.com/Automattic/juice/tree/v4.0.2#options)
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-inline-css",
   "description": "Takes an html file with css link and turns inline.  Great for emails.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/jgallen23/grunt-inline-css",
   "author": {
     "name": "Greg Allen"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "juice": "~3.0.1"
+    "juice": "~4.0.2"
   }
 }

--- a/tasks/inline_css.js
+++ b/tasks/inline_css.js
@@ -18,9 +18,12 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('inlinecss', 'Takes an html file with css link and turns inline.  Great for emails.', function() {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options();
+    var codeBlocks = this.data.codeBlocks;
     var done = this.async();
     var index = 0;
     var count = this.files.length;
+
+    juice.codeBlocks = Object.assign({}, juice.codeBlocks, codeBlocks);
 
     var increaseCount = function () {
       index++;


### PR DESCRIPTION
- Upgrade juice to 4.0.2
- Allow to configure juice.codeBlocks (https://github.com/Automattic/juice/commit/280c311f24e05b21f8e7a47c926eead1f2d06a4f)

Example configuration  with alternative syntax for FreeMarker template:

```js
inlinecss: {
    main: {
        codeBlocks: {
            fmOpen: {
                start: '[#',
                end: ']'
            },
            fmClose: {
                start: '[/#',
                end: ']'
            }
        },
        options: {},
        files: {}
    }
}
```