### PR TITLE
Allow to configure juice.codeBlocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ passed into `grunt.initConfig()`.
 grunt.initConfig({
     inlinecss: {
         main: {
+            codeBlocks: {
+            },
             options: {
             },
             files: {
@@ -48,6 +50,9 @@ grunt.initConfig({
 
 You can see available options
 [here](https://github.com/Automattic/juice/tree/v4.1.0#options)
+
+You can see how to use `codeBlocks`
+[here](https://github.com/Automattic/juice/tree/v4.1.0#juicecodeblocks)
 
 ## The "inlinecontent" task
 

--- a/tasks/inline_css.js
+++ b/tasks/inline_css.js
@@ -18,9 +18,12 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('inlinecss', 'Takes an html file with linked css files or separate css files and turns inline. Great for emails.', function() {
     // Merge task-specific and/or target-specific options with these defaults.
     const options = this.options();
+    const codeBlocks = this.data.codeBlocks;
     const done = this.async();
     let index = 0;
     const count = this.files.length;
+
+    juice.codeBlocks = Object.assign({}, juice.codeBlocks, codeBlocks);
 
     const increaseCount = function () {
       index++;


### PR DESCRIPTION
As discussed in: https://github.com/jgallen23/grunt-inline-css/pull/46

Allow to configure juice.codeBlocks (https://github.com/Automattic/juice/commit/280c311f24e05b21f8e7a47c926eead1f2d06a4f) to support general exclusion of fenced code, like EJS, HBS, etc.